### PR TITLE
Remove jsonp from Best Buy query builder

### DIFF
--- a/_built/appServices/httpclientService.js
+++ b/_built/appServices/httpclientService.js
@@ -3,11 +3,7 @@
 angular.module('appServices').factory('HttpClientService', ['$resource', function($resource) {
     
     var httpClient = function (query) {
-		return $resource(query, {}, {
-		    jsonp_query: {
-		        method: 'JSONP'
-		    }
-		});
+		return $resource(query, {});
 	};
 
 	return {

--- a/_built/categories/categories.html
+++ b/_built/categories/categories.html
@@ -86,8 +86,6 @@
 
                 <p ng-show="(pageSize !== 10) || (whichPage !== 1)"><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#pagination-pagination" target="_blank">pagination</a> : <span ng-show="(pageSize !== 10)">pageSize=<span ng-bind="pageSize"></span></span><span ng-show="(whichPage !== 1)">&page=<span ng-bind="whichPage"></span></span></p>
 
-                <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">callback</a> : &callback=JSON_CALLBACK</p>
-                
                 <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">responseFormat</a> : &format=json</p>
 
             </div>

--- a/_built/categories/categories.js
+++ b/_built/categories/categories.js
@@ -36,7 +36,7 @@ angular.module('bby-query-mixer.categories').controller('CategoriesCtrl', [
                     (queryParams += '&show=id,name'):'';
             
 
-            queryParams += '&callback=JSON_CALLBACK&format=json';
+            queryParams += '&format=json';
 
             return queryUrl + queryParams;
         };
@@ -58,7 +58,7 @@ angular.module('bby-query-mixer.categories').controller('CategoriesCtrl', [
                 var eventActionName = "categories query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             } else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";

--- a/_built/openBox/openBox.html
+++ b/_built/openBox/openBox.html
@@ -65,8 +65,6 @@
                 <p><a class="breakdownLabel" href="https://remix.mashery.com/member/register" target="_blank">apiKey</a> : ?apiKey=<span ng-bind="apiKey"></span><span ng-show="sortBy != 'none'"></p>
 
                 <p ng-show="(pageSize !== 10) || (whichPage !== 1)"><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#pagination-pagination" target="_blank">pagination</a> : <span ng-show="(pageSize !== 10)">pageSize=<span ng-bind="pageSize"></span></span><span ng-show="(whichPage !== 1)">&page=<span ng-bind="whichPage"></span></span></p>
-
-                <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">callback</a> : &callback=JSON_CALLBACK</span></p>
                 
 
             </div>

--- a/_built/openBox/openBox.js
+++ b/_built/openBox/openBox.js
@@ -18,8 +18,7 @@ angular.module('bby-query-mixer.openBox').controller('openBoxCtrl', [
             var skuListQuery = (($scope.searchSelection.value === 'skuList')&&($scope.skuList)) ? baseUrl += '(sku%20in('+$scope.skuList+'))':'';
             var singleSkuQuery = (($scope.searchSelection.value === 'singleSku')&&($scope.singleSku)) ? baseUrl = 'https://api.bestbuy.com/beta/products/'+$scope.singleSku +'/openBox' : '';
             var apiKey = $scope.apiKey ? baseUrl += '?apiKey='+$scope.apiKey : '';
-            
-            baseUrl += '&callback=JSON_CALLBACK' ;
+        
             
             var checkPageSize = (($scope.pageSize)&&($scope.pageSize !== 10)) ? baseUrl += '&pageSize='+$scope.pageSize : '';
             var checkWhichPage = (($scope.whichPage)&&($scope.whichPage !== 1)) ? baseUrl += '&page='+$scope.whichPage : '';
@@ -43,7 +42,7 @@ angular.module('bby-query-mixer.openBox').controller('openBoxCtrl', [
                 var eventActionName = "open box query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             }else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";

--- a/_built/productSearch/productSearch.html
+++ b/_built/productSearch/productSearch.html
@@ -126,8 +126,6 @@
 
                 <p ng-show="facetAttribute.productAttribute"><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#facets-facets" target="_blank">facets</a> : &facet=<span ng-bind="facetAttribute.productAttribute"></span><span ng-show="facetNumber">,<span ng-bind="facetNumber"></span></span></p>
 
-                <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">callback</a> : &callback=JSON_CALLBACK</span></p>
-
                 <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">responseFormat</a> : &format=json</p>
             </div>
         </div>

--- a/_built/productSearch/productSearch.js
+++ b/_built/productSearch/productSearch.js
@@ -77,7 +77,7 @@ angular.module('bby-query-mixer.productSearch').controller('ProductSearchCtrl', 
             var checkPageSize = (($scope.pageSize)&&($scope.pageSize !== 10)) ? paramArgs.push('pageSize='+$scope.pageSize) : '';
             var checkWhichPage = (($scope.whichPage)&&($scope.whichPage !== 1)) ? paramArgs.push('page='+$scope.whichPage) : '';
 
-            paramArgs.push('&format=json');
+            paramArgs.push('format=json');
 
             if (paramArgs.length > 0) {
                 return '?' + paramArgs.join('&');

--- a/_built/productSearch/productSearch.js
+++ b/_built/productSearch/productSearch.js
@@ -47,7 +47,7 @@ angular.module('bby-query-mixer.productSearch').controller('ProductSearchCtrl', 
                 var eventActionName = "products query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             }else{
                 $scope.errorResult = true;
                 $scope.remixResults = 'Please enter your API Key';
@@ -77,7 +77,7 @@ angular.module('bby-query-mixer.productSearch').controller('ProductSearchCtrl', 
             var checkPageSize = (($scope.pageSize)&&($scope.pageSize !== 10)) ? paramArgs.push('pageSize='+$scope.pageSize) : '';
             var checkWhichPage = (($scope.whichPage)&&($scope.whichPage !== 1)) ? paramArgs.push('page='+$scope.whichPage) : '';
 
-            paramArgs.push('callback=JSON_CALLBACK&format=json');
+            paramArgs.push('&format=json');
 
             if (paramArgs.length > 0) {
                 return '?' + paramArgs.join('&');

--- a/_built/production.js
+++ b/_built/production.js
@@ -225,11 +225,7 @@ angular.module('appServices').factory('GaService', [ function() {
 angular.module('appServices').factory('HttpClientService', ['$resource', function($resource) {
     
     var httpClient = function (query) {
-		return $resource(query, {}, {
-		    jsonp_query: {
-		        method: 'JSONP'
-		    }
-		});
+		return $resource(query, {});
 	};
 
 	return {
@@ -280,8 +276,7 @@ angular.module('bby-query-mixer.openBox').controller('openBoxCtrl', [
             var skuListQuery = (($scope.searchSelection.value === 'skuList')&&($scope.skuList)) ? baseUrl += '(sku%20in('+$scope.skuList+'))':'';
             var singleSkuQuery = (($scope.searchSelection.value === 'singleSku')&&($scope.singleSku)) ? baseUrl = 'https://api.bestbuy.com/beta/products/'+$scope.singleSku +'/openBox' : '';
             var apiKey = $scope.apiKey ? baseUrl += '?apiKey='+$scope.apiKey : '';
-            
-            baseUrl += '&callback=JSON_CALLBACK' ;
+        
             
             var checkPageSize = (($scope.pageSize)&&($scope.pageSize !== 10)) ? baseUrl += '&pageSize='+$scope.pageSize : '';
             var checkWhichPage = (($scope.whichPage)&&($scope.whichPage !== 1)) ? baseUrl += '&page='+$scope.whichPage : '';
@@ -305,7 +300,7 @@ angular.module('bby-query-mixer.openBox').controller('openBoxCtrl', [
                 var eventActionName = "open box query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             }else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";
@@ -452,7 +447,7 @@ angular.module('bby-query-mixer.productSearch').controller('ProductSearchCtrl', 
                 var eventActionName = "products query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             }else{
                 $scope.errorResult = true;
                 $scope.remixResults = 'Please enter your API Key';
@@ -482,7 +477,7 @@ angular.module('bby-query-mixer.productSearch').controller('ProductSearchCtrl', 
             var checkPageSize = (($scope.pageSize)&&($scope.pageSize !== 10)) ? paramArgs.push('pageSize='+$scope.pageSize) : '';
             var checkWhichPage = (($scope.whichPage)&&($scope.whichPage !== 1)) ? paramArgs.push('page='+$scope.whichPage) : '';
 
-            paramArgs.push('callback=JSON_CALLBACK&format=json');
+            paramArgs.push('&format=json');
 
             if (paramArgs.length > 0) {
                 return '?' + paramArgs.join('&');
@@ -692,7 +687,7 @@ angular.module('bby-query-mixer.recommendations').controller('RecommendationsCtr
             var endpointSelection = $scope.endpoint.selected ? baseUrl += ($scope.endpoint.selected) : '';
             var categoryOption = $scope.category.value ? baseUrl += ('(categoryId='+$scope.category.value+')') : '';
             var addKey = $scope.apiKey ? baseUrl += ('?apiKey='+$scope.apiKey):'';
-            baseUrl += '&callback=JSON_CALLBACK';
+
             return baseUrl;
         };
 
@@ -713,7 +708,7 @@ angular.module('bby-query-mixer.recommendations').controller('RecommendationsCtr
                 var eventActionName = "recommendation query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             }else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";
@@ -768,7 +763,6 @@ angular.module('bby-query-mixer.smartLists').controller('SmartListsCtrl', [
             var baseUrl = 'https://api.bestbuy.com/beta/products/';
             var endpointSelection = $scope.endpoint.selected ? baseUrl += ($scope.endpoint.selected) : '';
             var addKey = $scope.apiKey ? baseUrl += ('?apiKey='+$scope.apiKey):'';
-            baseUrl += '&callback=JSON_CALLBACK';
             return baseUrl;
         };
 
@@ -789,7 +783,7 @@ angular.module('bby-query-mixer.smartLists').controller('SmartListsCtrl', [
                 var eventActionName = "smart lists query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             }else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";
@@ -1026,7 +1020,7 @@ angular.module('bby-query-mixer.stores').controller('storesCtrl', [
             var checkPageSize = (($scope.pageSize)&&($scope.pageSize !== 10)) ? queryParams.push('&pageSize='+$scope.pageSize) : '';
             var checkWhichPage = (($scope.whichPage)&&($scope.whichPage !== 1)) ? queryParams.push('&page='+$scope.whichPage) : '';
                         
-            queryParams.push('&callback=JSON_CALLBACK&format=json');
+            queryParams.push('&format=json');
             var parensCheck = searchArgs.length === 0 ? baseUrl += (searchArgs.join('')) : baseUrl += ('('+searchArgs.join('&')+')');
             baseUrl += queryParams.join('');
             return baseUrl
@@ -1049,7 +1043,7 @@ angular.module('bby-query-mixer.stores').controller('storesCtrl', [
                 var eventActionName = "stores query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             } else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";
@@ -1201,7 +1195,7 @@ angular.module('bby-query-mixer.categories').controller('CategoriesCtrl', [
                     (queryParams += '&show=id,name'):'';
             
 
-            queryParams += '&callback=JSON_CALLBACK&format=json';
+            queryParams += '&format=json';
 
             return queryUrl + queryParams;
         };
@@ -1223,7 +1217,7 @@ angular.module('bby-query-mixer.categories').controller('CategoriesCtrl', [
                 var eventActionName = "categories query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             } else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";

--- a/_built/recommendations/recommendations.html
+++ b/_built/recommendations/recommendations.html
@@ -52,7 +52,6 @@
                     <p ng-show="endpoint.selected"><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation/recommendations-api" target="_blank">endpoint</a> : <span ng-bind="endpoint.selected"></span></p>
                     <p ng-show="category.value"><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation/products-api#documentation/products-api-categorizations" target="_blank">categoryId</a> : (categoryPath.id=<span ng-bind="category.value"></span>)</p>
                     <p><a class="breakdownLabel" href="https://remix.mashery.com/member/register" target="_blank">apiKey</a> : ?apiKey=<span ng-bind="apiKey"></span><span ng-show="sortBy != 'none'"></p>
-                    <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">callback</a> : &callback=JSON_CALLBACK</span></p>
                 </div>
             </div>
         <h4 class="container">Complete URL</h4>

--- a/_built/recommendations/recommendations.js
+++ b/_built/recommendations/recommendations.js
@@ -15,7 +15,7 @@ angular.module('bby-query-mixer.recommendations').controller('RecommendationsCtr
             var endpointSelection = $scope.endpoint.selected ? baseUrl += ($scope.endpoint.selected) : '';
             var categoryOption = $scope.category.value ? baseUrl += ('(categoryId='+$scope.category.value+')') : '';
             var addKey = $scope.apiKey ? baseUrl += ('?apiKey='+$scope.apiKey):'';
-            baseUrl += '&callback=JSON_CALLBACK';
+
             return baseUrl;
         };
 
@@ -36,7 +36,7 @@ angular.module('bby-query-mixer.recommendations').controller('RecommendationsCtr
                 var eventActionName = "recommendation query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             }else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";

--- a/_built/smartLists/smartLists.html
+++ b/_built/smartLists/smartLists.html
@@ -45,7 +45,6 @@
                     <p ng-show="endpoint.selected"><a class="breakdownLabel" href="" target="_blank">endpoint</a> : <span ng-bind="endpoint.selected"></span></p>
                     <p ng-show="category.value"><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation/products-api#documentation/products-api-categorizations" target="_blank">categoryId</a> : (categoryPath.id=<span ng-bind="category.value"></span>)</p>
                     <p><a class="breakdownLabel" href="https://remix.mashery.com/member/register" target="_blank">apiKey</a> : ?apiKey=<span ng-bind="apiKey"></span><span ng-show="sortBy != 'none'"></p>
-                    <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">callback</a> : &callback=JSON_CALLBACK</span></p>
                 </div>
             </div>
         <h4 class="container">Complete URL</h4>

--- a/_built/smartLists/smartLists.js
+++ b/_built/smartLists/smartLists.js
@@ -11,7 +11,6 @@ angular.module('bby-query-mixer.smartLists').controller('SmartListsCtrl', [
             var baseUrl = 'https://api.bestbuy.com/beta/products/';
             var endpointSelection = $scope.endpoint.selected ? baseUrl += ($scope.endpoint.selected) : '';
             var addKey = $scope.apiKey ? baseUrl += ('?apiKey='+$scope.apiKey):'';
-            baseUrl += '&callback=JSON_CALLBACK';
             return baseUrl;
         };
 
@@ -32,7 +31,7 @@ angular.module('bby-query-mixer.smartLists').controller('SmartListsCtrl', [
                 var eventActionName = "smart lists query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             }else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";

--- a/_built/stores/stores.html
+++ b/_built/stores/stores.html
@@ -181,8 +181,6 @@
 
                 <p ng-show="(pageSize !== 10) || (whichPage !== 1)"><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#pagination-pagination" target="_blank">pagination</a> : <span ng-show="(pageSize !== 10)">pageSize=<span ng-bind="pageSize"></span></span><span ng-show="(whichPage !== 1)">&page=<span ng-bind="whichPage"></span></span></p>
 
-                <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">callback</a> : &callback=JSON_CALLBACK</p>
-
                 <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">responseFormat</a> : &format=json</p>
 
 

--- a/_built/stores/stores.js
+++ b/_built/stores/stores.js
@@ -62,7 +62,7 @@ angular.module('bby-query-mixer.stores').controller('storesCtrl', [
             var checkPageSize = (($scope.pageSize)&&($scope.pageSize !== 10)) ? queryParams.push('&pageSize='+$scope.pageSize) : '';
             var checkWhichPage = (($scope.whichPage)&&($scope.whichPage !== 1)) ? queryParams.push('&page='+$scope.whichPage) : '';
                         
-            queryParams.push('&callback=JSON_CALLBACK&format=json');
+            queryParams.push('&format=json');
             var parensCheck = searchArgs.length === 0 ? baseUrl += (searchArgs.join('')) : baseUrl += ('('+searchArgs.join('&')+')');
             baseUrl += queryParams.join('');
             return baseUrl
@@ -85,7 +85,7 @@ angular.module('bby-query-mixer.stores').controller('storesCtrl', [
                 var eventActionName = "stores query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             } else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";

--- a/_built/test/categories_test.js
+++ b/_built/test/categories_test.js
@@ -39,24 +39,24 @@ describe('bby-query-mixer.categories module', function () {
 	        expect(scope.buildRemixQuery).toBeDefined();
 	    });
 	    it('should build a query string', function (){
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories?apiKey=youreAnApiKey&format=json');
 	    });
 	    it('should update pagination in the query string', function (){
 	        scope.pageSize = '12';
 	        scope.whichPage = '3';
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories?apiKey=youreAnApiKey&pageSize=12&page=3&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories?apiKey=youreAnApiKey&pageSize=12&page=&format=json');
 	    });
 	   	it('should add category name if needed', function (){
 	        scope.categoryName = 'awesomeProducts';
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories(name=awesomeProducts*)?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories(name=awesomeProducts*)?apiKey=youreAnApiKey&format=json');
 	    });
 	   	it('should add category id if needed', function (){
 	        scope.categoryId = 'abcat0401000';
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories(id=abcat0401000)?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories(id=abcat0401000)?apiKey=youreAnApiKey&format=json');
 	    });
 	   	it('should add the correct response attributes', function (){
 	        scope.categoryResponse.list = ['id','name','subcategory'];
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories?apiKey=youreAnApiKey&show=id,name,subcategory&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories?apiKey=youreAnApiKey&show=id,name,subcategory&format=json');
 	    });	 	    
     });
 

--- a/_built/test/categories_test.js
+++ b/_built/test/categories_test.js
@@ -44,7 +44,7 @@ describe('bby-query-mixer.categories module', function () {
 	    it('should update pagination in the query string', function (){
 	        scope.pageSize = '12';
 	        scope.whichPage = '3';
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories?apiKey=youreAnApiKey&pageSize=12&page=&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories?apiKey=youreAnApiKey&pageSize=12&page=3&format=json');
 	    });
 	   	it('should add category name if needed', function (){
 	        scope.categoryName = 'awesomeProducts';

--- a/_built/test/openBox_test.js
+++ b/_built/test/openBox_test.js
@@ -31,31 +31,31 @@ describe('bby-query-mixer.productSearch module', function () {
                 expect(scope.buildRemixQuery).toBeDefined();
             });
             it('should build a query string', function (){
-                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox&callback=JSON_CALLBACK');
+                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox');
             });
             it('should update pagination in the query string', function (){
                 scope.pageSize = '12';
                 scope.whichPage = '3';
-                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox&callback=JSON_CALLBACK&pageSize=12&page=3');
+                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox&pageSize=12&page=3');
             });
             it('should search by category id', function (){
                 scope.searchSelection.value = "category";
                 scope.category.value = 'pcmcat209400050001'
-                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox(categoryId=pcmcat209400050001)&callback=JSON_CALLBACK');
+                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox(categoryId=pcmcat209400050001)');
             });
             it('should search for all skus', function (){
                 scope.searchSelection.value = "allSkus";
-                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox&callback=JSON_CALLBACK');
+                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox');
             });
             it('should add list of skus', function (){
                 scope.searchSelection.value = "skuList";
                 scope.skuList = '123,321';
-                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox(sku%20in(123,321))&callback=JSON_CALLBACK');
+                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox(sku%20in(123,321))');
             });
             it('should add singlesku', function (){
                 scope.searchSelection.value = "singleSku";
                 scope.singleSku = '123';
-                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/123/openBox&callback=JSON_CALLBACK');
+                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/123/openBox');
             });
     });
 

--- a/_built/test/productSearch_test.js
+++ b/_built/test/productSearch_test.js
@@ -34,28 +34,28 @@ describe('bby-query-mixer.productSearch module', function () {
 
             it('should return a url when apikey passed in', function () {
                 scope.apiKey = "youreAnApiKey";
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products?apiKey=youreAnApiKey&format=json");
             });
 
             it('should return a query string with no apiKey parameter when no key provided', function () {
                 scope.apiKey='';
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products?callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products");
             });
 
             it('should update the category id value when category is changed', function () {
                 scope.category = {
                     value: "abcat33"
                 };
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products((categoryPath.id=abcat33))?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products((categoryPath.id=abcat33))?apiKey=youreAnApiKey&format=json");
                 scope.category.value = "abcat34";
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products((categoryPath.id=abcat34))?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products((categoryPath.id=abcat34))?apiKey=youreAnApiKey&format=json");
             });
 
             it('should return a query string with a sort filter and sortOrder when specified', function () {
                 scope.category.value = "someCategory";
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products((categoryPath.id=someCategory))?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products((categoryPath.id=someCategory))?apiKey=youreAnApiKey&format=json");
                 scope.sortOrder.value = "desc";
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products((categoryPath.id=someCategory))?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products((categoryPath.id=someCategory))?apiKey=youreAnApiKey&format=json");
             });
             it('should return the right parens when sku in query is made', function () {
                 scope.dynamicForms= [{value:{productAttribute:'sku'},opt:{value:' in '},complexVal:'123, 456'}]
@@ -64,28 +64,28 @@ describe('bby-query-mixer.productSearch module', function () {
                 scope.attributeOption.value = 'sku';
                 scope.operator.value = ' in ';
                 scope.complexVal = '123, 456';
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(sku in (123, 456))?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(sku in (123, 456))?apiKey=youreAnApiKey&format=json");
             });
             it('should add an asterisk after category path name', function () {
                 scope.dynamicForms= [{value:{productAttribute:'categoryPath.name'},opt:{value:'='},complexVal:'Home Theater'}]
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(categoryPath.name=Home Theater*)?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(categoryPath.name=Home Theater*)?apiKey=youreAnApiKey&format=json");
             });            
             it('should return add faceting when specified', function () {
                 scope.facetAttribute.productAttribute = 'color';
                 scope.facetNumber = 11;
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products?apiKey=youreAnApiKey&facet=color,11&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products?apiKey=youreAnApiKey&facet=color,11&format=json");
             });
             it('should add bad values to query so that remix returns the proper error status', function () {
                 scope.dynamicForms= [{value:{productAttribute:'bestSellingRank'},opt:{value:'='},complexVal:'wwwwwwwwww'}]
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(bestSellingRank=wwwwwwwwww)?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(bestSellingRank=wwwwwwwwww)?apiKey=youreAnApiKey&format=json");
             });
             it('should add the star value to the query when selected', function () {
                 scope.dynamicForms= [{value:{productAttribute:'onSale'},opt:{value:'='},complexVal:'*'}];
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(onSale=*)?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(onSale=*)?apiKey=youreAnApiKey&format=json");
             });
             it('should allow invalid page sizes so remix can return the real error message', function () {
                 scope.pageSize = 111;
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products?apiKey=youreAnApiKey&pageSize=111&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products?apiKey=youreAnApiKey&pageSize=111&format=json");
             });              
         });
         describe('buildParams function', function () {
@@ -93,36 +93,36 @@ describe('bby-query-mixer.productSearch module', function () {
                 scope.apiKey = '';
                 scope.sortBy = {value : 'sku'};
                 scope.sortOrder.value = 'asc';
-                expect(scope.buildParams()).toEqual('?sort=sku.asc&callback=JSON_CALLBACK&format=json');
+                expect(scope.buildParams()).toEqual('?sort=sku.asc&format=json');
             });
             it('should return sortBy and sortOrder asc when only sortBy selected', function () {
                 scope.apiKey = '';
                 scope.sortBy = {value : 'sku'};
                 scope.sortOrder.value = 'desc';
 
-                expect(scope.buildParams()).toEqual('?sort=sku.desc&callback=JSON_CALLBACK&format=json');
+                expect(scope.buildParams()).toEqual('?sort=sku.desc&format=json');
             });
             it('should return apiKey when only apiKey specified', function () {
                 scope.apiKey = 'someApiKey';
-                expect(scope.buildParams()).toEqual('?apiKey=someApiKey&callback=JSON_CALLBACK&format=json');
+                expect(scope.buildParams()).toEqual('?apiKey=someApiKey&format=json');
             });
             it('should return both apiKey and sortBy with sortOrder when both specified', function () {
                 scope.apiKey = 'someApiKey';
                 scope.sortBy = {value : 'sku'};
                 scope.sortOrder.value = 'desc';
 
-                expect(scope.buildParams()).toEqual('?apiKey=someApiKey&sort=sku.desc&callback=JSON_CALLBACK&format=json');
+                expect(scope.buildParams()).toEqual('?apiKey=someApiKey&sort=sku.desc&format=json');
             });
             it('should add faceting when it\'s defined', function () {
                 scope.facetAttribute.productAttribute = 'manufacturer';
                 scope.facetNumber = '3';
-                expect(scope.buildParams()).toEqual('?apiKey=youreAnApiKey&facet=manufacturer,3&callback=JSON_CALLBACK&format=json');
+                expect(scope.buildParams()).toEqual('?apiKey=youreAnApiKey&facet=manufacturer,3&format=json');
             });
             it('construct pagination only when needed', function () {
-                expect(scope.buildParams()).toEqual('?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json');
+                expect(scope.buildParams()).toEqual('?apiKey=youreAnApiKey&format=json');
                 scope.pageSize = 11;
                 scope.whichPage = 3;
-                expect(scope.buildParams()).toEqual('?apiKey=youreAnApiKey&pageSize=11&page=3&callback=JSON_CALLBACK&format=json');
+                expect(scope.buildParams()).toEqual('?apiKey=youreAnApiKey&pageSize=11&page=3&format=json');
             });
         });
         describe('reset query function', function () {
@@ -165,7 +165,7 @@ describe('bby-query-mixer.productSearch module', function () {
         describe('dynamic forms functionality', function () {
             it('should compile the array of forms and add it to the remix query url', function () {
                 scope.dynamicForms= [{value:{productAttribute:'foo'},opt:{value:'='},complexVal:'foo'}]
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(foo=foo)?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(foo=foo)?apiKey=youreAnApiKey&format=json");
             });
              it('should add/delete forms from the dynamic attributes list', function () {
                 scope.dynamicForms = [{value:{productAttribute:'foo'},opt:{value:'='},complexVal:'foo'}]

--- a/_built/test/productSearch_test.js
+++ b/_built/test/productSearch_test.js
@@ -39,7 +39,7 @@ describe('bby-query-mixer.productSearch module', function () {
 
             it('should return a query string with no apiKey parameter when no key provided', function () {
                 scope.apiKey='';
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products?format=json");
             });
 
             it('should update the category id value when category is changed', function () {

--- a/_built/test/recommendations_test.js
+++ b/_built/test/recommendations_test.js
@@ -65,7 +65,7 @@ describe('bby-query-mixer.recommendations module', function () {
             });
 
             it('should return an error in an array on a failing response', function () {
-                $httpBackend.expectJSONP('https://api.bestbuy.com/beta/products/trendingViewed?apiKey=inactiveKey').respond(403, {
+                $httpBackend.expectGET('https://api.bestbuy.com/beta/products/trendingViewed?apiKey=inactiveKey').respond(403, {
                     status: 403,
                     errorMessage: "Account Inactive",
                     help: "http://developer.bestbuy.com/get-started"

--- a/_built/test/recommendations_test.js
+++ b/_built/test/recommendations_test.js
@@ -49,7 +49,7 @@ describe('bby-query-mixer.recommendations module', function () {
 
             it('should return a url when apiKey is supplied', function () {
                 scope.apiKey = 'someApiKey';
-                expect(scope.buildRecommendationsQuery()).toEqual('https://api.bestbuy.com/beta/products/?apiKey=someApiKey&callback=JSON_CALLBACK')
+                expect(scope.buildRecommendationsQuery()).toEqual('https://api.bestbuy.com/beta/products/?apiKey=someApiKey')
             });
         });
 
@@ -65,7 +65,7 @@ describe('bby-query-mixer.recommendations module', function () {
             });
 
             it('should return an error in an array on a failing response', function () {
-                $httpBackend.expectJSONP('https://api.bestbuy.com/beta/products/trendingViewed?apiKey=inactiveKey&callback=JSON_CALLBACK').respond(403, {
+                $httpBackend.expectJSONP('https://api.bestbuy.com/beta/products/trendingViewed?apiKey=inactiveKey').respond(403, {
                     status: 403,
                     errorMessage: "Account Inactive",
                     help: "http://developer.bestbuy.com/get-started"

--- a/_built/test/smartLists_test.js
+++ b/_built/test/smartLists_test.js
@@ -23,9 +23,9 @@ describe('bby-query-mixer.smartLists module', function () {
             });
             it('should add the appropriate endpoint', function (){
                 scope.endpoint.selected = 'activeAdventurer';
-                expect(scope.buildSmartListsQuery()).toEqual('https://api.bestbuy.com/beta/products/activeAdventurer&callback=JSON_CALLBACK');
+                expect(scope.buildSmartListsQuery()).toEqual('https://api.bestbuy.com/beta/products/activeAdventurer');
                 scope.endpoint.selected = 'connectedHome';
-                expect(scope.buildSmartListsQuery()).toEqual('https://api.bestbuy.com/beta/products/connectedHome&callback=JSON_CALLBACK');            
+                expect(scope.buildSmartListsQuery()).toEqual('https://api.bestbuy.com/beta/products/connectedHome');            
             });
         });
         describe('invoke recommendations query function', function (){

--- a/_built/test/stores_test.js
+++ b/_built/test/stores_test.js
@@ -37,78 +37,78 @@ describe('bby-query-mixer.stores module', function () {
 	    	expect(scope.buildRemixQuery).toBeDefined();
 	    });
 	    it('should build a query string', function (){
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores?apiKey=testKey&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores?apiKey=testKey&format=json');
 	    });
 	    it('should update pagination in the query string', function (){
 	        var queryParams = [];
 	        scope.pageSize = '12';
 	        scope.whichPage = '3';
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores?apiKey=testKey&pageSize=12&page=3&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores?apiKey=testKey&pageSize=12&page=3&format=json');
 	    });
 	    it('should add an ampersand in front of services list, but only if needed', function (){
 	     	scope.apiKey = 'testKey';   	        
 	        scope.searchSelection.value = 'city';
 	        scope.servicesOption.list = ['foo'];
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((city=)&((services.service=foo)))?apiKey=testKey&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((city=)&((services.service=foo)))?apiKey=testKey&format=json');
 	        scope.searchSelection.value = false;
-            expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((services.service=foo))?apiKey=testKey&callback=JSON_CALLBACK&format=json');
+            expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((services.service=foo))?apiKey=testKey&format=json');
 	    });
 	   	it('should add list of SKUs to the url', function (){
 	        scope.skuList = '6461052,5909042';
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores+products(sku%20in%20(6461052,5909042))?apiKey=testKey&show=products.sku,products.name,products.shortDescription,products.salePrice,products.regularPrice,products.addToCartURL,products.url,products.image,products.customerReviewCount,products.customerReviewAverage&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores+products(sku%20in%20(6461052,5909042))?apiKey=testKey&show=products.sku,products.name,products.shortDescription,products.salePrice,products.regularPrice,products.addToCartURL,products.url,products.image,products.customerReviewCount,products.customerReviewAverage&format=json');
 	    });
 	   	it('should add list of product options to the url', function (){
 	        scope.skuList = '6461052,5909042';
 	        scope.productOption.list = 'products.shortDescription'
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores+products(sku%20in%20(6461052,5909042))?apiKey=testKey&show=products.shortDescription&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores+products(sku%20in%20(6461052,5909042))?apiKey=testKey&show=products.shortDescription&format=json');
 	    });
 	   	it('should add list of store response options to the url', function (){
 	        scope.storeResponse.list = ['hours','name'];
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores?apiKey=testKey&show=hours,name&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores?apiKey=testKey&show=hours,name&format=json');
 	    });	 	   
 	   	it('should add list of product options AND store response options to the url', function (){
 	        scope.skuList = '6461052,5909042';
 	        scope.storeResponse.list = ['name','hours'];
 	        scope.productOption.list = 'products.shortDescription'
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores+products(sku%20in%20(6461052,5909042))?apiKey=testKey&show=products.shortDescription,name,hours&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores+products(sku%20in%20(6461052,5909042))?apiKey=testKey&show=products.shortDescription,name,hours&format=json');
 	    });
 	    it('should search by city', function () {
 	    	scope.searchSelection.value = 'city';
 	    	scope.cityChoice = "EmeraldCity";
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((city=EmeraldCity))?apiKey=testKey&callback=JSON_CALLBACK&format=json')
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((city=EmeraldCity))?apiKey=testKey&format=json')
 	    });
 	    it('should search by postal code', function () {
 	    	scope.zipCode = '12345';
-            expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((postalCode=12345))?apiKey=testKey&callback=JSON_CALLBACK&format=json')
+            expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((postalCode=12345))?apiKey=testKey&format=json')
 
 	    });
 	    it('should search by lat long', function () {
 	    	scope.longitude = 50;
 	    	scope.latitude = 50;
-	    	expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((area(50,50,)))?apiKey=testKey&callback=JSON_CALLBACK&format=json')
+	    	expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((area(50,50,)))?apiKey=testKey&format=json')
 
 	    });	
 	    it('should search by storeid', function () {
 			scope.searchSelection.value = 'storeId';
 			scope.storeId = '54321';
-			expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((storeId=54321))?apiKey=testKey&callback=JSON_CALLBACK&format=json')
+			expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((storeId=54321))?apiKey=testKey&format=json')
 	    });	        	    		     
 	    it('should search by region/state', function () {
 			scope.searchSelection.value ='region';
 			scope.regionOption = {value:"Minnesota"};
-			expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((region=Minnesota))?apiKey=testKey&callback=JSON_CALLBACK&format=json');
+			expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((region=Minnesota))?apiKey=testKey&format=json');
 	    });   
 	    it('should add a key', function () {
 	    	scope.apiKey = "mySuperSecretApiKey";
-	    	expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores?apiKey=mySuperSecretApiKey&callback=JSON_CALLBACK&format=json');
+	    	expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores?apiKey=mySuperSecretApiKey&format=json');
 	    }); 	
 	   	it('should add store types', function () {
 	    	scope.storeType.list = ['Big Box', 'Express'];
-	    	expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores(((storeType=Big Box)|(storeType=Express)))?apiKey=testKey&callback=JSON_CALLBACK&format=json');
+	    	expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores(((storeType=Big Box)|(storeType=Express)))?apiKey=testKey&format=json');
 	    });  
 	   	it('should add store services', function () {
 	    	scope.servicesOption.list = ['Geek Squad', 'Best Buy for Enterprise'];
-	    	expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((services.service=Geek Squad)&(services.service=Best Buy for Enterprise))?apiKey=testKey&callback=JSON_CALLBACK&format=json');
+	    	expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((services.service=Geek Squad)&(services.service=Best Buy for Enterprise))?apiKey=testKey&format=json');
 	    });     
     });
 

--- a/app/appServices/httpclientService.js
+++ b/app/appServices/httpclientService.js
@@ -3,11 +3,7 @@
 angular.module('appServices').factory('HttpClientService', ['$resource', function($resource) {
     
     var httpClient = function (query) {
-		return $resource(query, {}, {
-		    jsonp_query: {
-		        method: 'JSONP'
-		    }
-		});
+		return $resource(query, {});
 	};
 
 	return {

--- a/app/categories/categories.html
+++ b/app/categories/categories.html
@@ -86,8 +86,6 @@
 
                 <p ng-show="(pageSize !== 10) || (whichPage !== 1)"><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#pagination-pagination" target="_blank">pagination</a> : <span ng-show="(pageSize !== 10)">pageSize=<span ng-bind="pageSize"></span></span><span ng-show="(whichPage !== 1)">&page=<span ng-bind="whichPage"></span></span></p>
 
-                <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">callback</a> : &callback=JSON_CALLBACK</p>
-                
                 <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">responseFormat</a> : &format=json</p>
 
             </div>

--- a/app/categories/categories.js
+++ b/app/categories/categories.js
@@ -36,7 +36,7 @@ angular.module('bby-query-mixer.categories').controller('CategoriesCtrl', [
                     (queryParams += '&show=id,name'):'';
             
 
-            queryParams += '&callback=JSON_CALLBACK&format=json';
+            queryParams += '&format=json';
 
             return queryUrl + queryParams;
         };
@@ -58,7 +58,7 @@ angular.module('bby-query-mixer.categories').controller('CategoriesCtrl', [
                 var eventActionName = "categories query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             } else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";

--- a/app/openBox/openBox.html
+++ b/app/openBox/openBox.html
@@ -65,8 +65,6 @@
                 <p><a class="breakdownLabel" href="https://remix.mashery.com/member/register" target="_blank">apiKey</a> : ?apiKey=<span ng-bind="apiKey"></span><span ng-show="sortBy != 'none'"></p>
 
                 <p ng-show="(pageSize !== 10) || (whichPage !== 1)"><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#pagination-pagination" target="_blank">pagination</a> : <span ng-show="(pageSize !== 10)">pageSize=<span ng-bind="pageSize"></span></span><span ng-show="(whichPage !== 1)">&page=<span ng-bind="whichPage"></span></span></p>
-
-                <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">callback</a> : &callback=JSON_CALLBACK</span></p>
                 
 
             </div>

--- a/app/openBox/openBox.js
+++ b/app/openBox/openBox.js
@@ -18,8 +18,7 @@ angular.module('bby-query-mixer.openBox').controller('openBoxCtrl', [
             var skuListQuery = (($scope.searchSelection.value === 'skuList')&&($scope.skuList)) ? baseUrl += '(sku%20in('+$scope.skuList+'))':'';
             var singleSkuQuery = (($scope.searchSelection.value === 'singleSku')&&($scope.singleSku)) ? baseUrl = 'https://api.bestbuy.com/beta/products/'+$scope.singleSku +'/openBox' : '';
             var apiKey = $scope.apiKey ? baseUrl += '?apiKey='+$scope.apiKey : '';
-            
-            baseUrl += '&callback=JSON_CALLBACK' ;
+        
             
             var checkPageSize = (($scope.pageSize)&&($scope.pageSize !== 10)) ? baseUrl += '&pageSize='+$scope.pageSize : '';
             var checkWhichPage = (($scope.whichPage)&&($scope.whichPage !== 1)) ? baseUrl += '&page='+$scope.whichPage : '';
@@ -43,7 +42,7 @@ angular.module('bby-query-mixer.openBox').controller('openBoxCtrl', [
                 var eventActionName = "open box query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             }else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";

--- a/app/productSearch/productSearch.html
+++ b/app/productSearch/productSearch.html
@@ -126,8 +126,6 @@
 
                 <p ng-show="facetAttribute.productAttribute"><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#facets-facets" target="_blank">facets</a> : &facet=<span ng-bind="facetAttribute.productAttribute"></span><span ng-show="facetNumber">,<span ng-bind="facetNumber"></span></span></p>
 
-                <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">callback</a> : &callback=JSON_CALLBACK</span></p>
-
                 <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">responseFormat</a> : &format=json</p>
             </div>
         </div>

--- a/app/productSearch/productSearch.js
+++ b/app/productSearch/productSearch.js
@@ -77,7 +77,7 @@ angular.module('bby-query-mixer.productSearch').controller('ProductSearchCtrl', 
             var checkPageSize = (($scope.pageSize)&&($scope.pageSize !== 10)) ? paramArgs.push('pageSize='+$scope.pageSize) : '';
             var checkWhichPage = (($scope.whichPage)&&($scope.whichPage !== 1)) ? paramArgs.push('page='+$scope.whichPage) : '';
 
-            paramArgs.push('&format=json');
+            paramArgs.push('format=json');
 
             if (paramArgs.length > 0) {
                 return '?' + paramArgs.join('&');

--- a/app/productSearch/productSearch.js
+++ b/app/productSearch/productSearch.js
@@ -47,7 +47,7 @@ angular.module('bby-query-mixer.productSearch').controller('ProductSearchCtrl', 
                 var eventActionName = "products query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             }else{
                 $scope.errorResult = true;
                 $scope.remixResults = 'Please enter your API Key';
@@ -77,7 +77,7 @@ angular.module('bby-query-mixer.productSearch').controller('ProductSearchCtrl', 
             var checkPageSize = (($scope.pageSize)&&($scope.pageSize !== 10)) ? paramArgs.push('pageSize='+$scope.pageSize) : '';
             var checkWhichPage = (($scope.whichPage)&&($scope.whichPage !== 1)) ? paramArgs.push('page='+$scope.whichPage) : '';
 
-            paramArgs.push('callback=JSON_CALLBACK&format=json');
+            paramArgs.push('&format=json');
 
             if (paramArgs.length > 0) {
                 return '?' + paramArgs.join('&');

--- a/app/production.js
+++ b/app/production.js
@@ -477,7 +477,7 @@ angular.module('bby-query-mixer.productSearch').controller('ProductSearchCtrl', 
             var checkPageSize = (($scope.pageSize)&&($scope.pageSize !== 10)) ? paramArgs.push('pageSize='+$scope.pageSize) : '';
             var checkWhichPage = (($scope.whichPage)&&($scope.whichPage !== 1)) ? paramArgs.push('page='+$scope.whichPage) : '';
 
-            paramArgs.push('&format=json');
+            paramArgs.push('format=json');
 
             if (paramArgs.length > 0) {
                 return '?' + paramArgs.join('&');

--- a/app/production.js
+++ b/app/production.js
@@ -225,11 +225,7 @@ angular.module('appServices').factory('GaService', [ function() {
 angular.module('appServices').factory('HttpClientService', ['$resource', function($resource) {
     
     var httpClient = function (query) {
-		return $resource(query, {}, {
-		    jsonp_query: {
-		        method: 'JSONP'
-		    }
-		});
+		return $resource(query, {});
 	};
 
 	return {
@@ -280,8 +276,7 @@ angular.module('bby-query-mixer.openBox').controller('openBoxCtrl', [
             var skuListQuery = (($scope.searchSelection.value === 'skuList')&&($scope.skuList)) ? baseUrl += '(sku%20in('+$scope.skuList+'))':'';
             var singleSkuQuery = (($scope.searchSelection.value === 'singleSku')&&($scope.singleSku)) ? baseUrl = 'https://api.bestbuy.com/beta/products/'+$scope.singleSku +'/openBox' : '';
             var apiKey = $scope.apiKey ? baseUrl += '?apiKey='+$scope.apiKey : '';
-            
-            baseUrl += '&callback=JSON_CALLBACK' ;
+        
             
             var checkPageSize = (($scope.pageSize)&&($scope.pageSize !== 10)) ? baseUrl += '&pageSize='+$scope.pageSize : '';
             var checkWhichPage = (($scope.whichPage)&&($scope.whichPage !== 1)) ? baseUrl += '&page='+$scope.whichPage : '';
@@ -305,7 +300,7 @@ angular.module('bby-query-mixer.openBox').controller('openBoxCtrl', [
                 var eventActionName = "open box query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             }else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";
@@ -452,7 +447,7 @@ angular.module('bby-query-mixer.productSearch').controller('ProductSearchCtrl', 
                 var eventActionName = "products query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             }else{
                 $scope.errorResult = true;
                 $scope.remixResults = 'Please enter your API Key';
@@ -482,7 +477,7 @@ angular.module('bby-query-mixer.productSearch').controller('ProductSearchCtrl', 
             var checkPageSize = (($scope.pageSize)&&($scope.pageSize !== 10)) ? paramArgs.push('pageSize='+$scope.pageSize) : '';
             var checkWhichPage = (($scope.whichPage)&&($scope.whichPage !== 1)) ? paramArgs.push('page='+$scope.whichPage) : '';
 
-            paramArgs.push('callback=JSON_CALLBACK&format=json');
+            paramArgs.push('&format=json');
 
             if (paramArgs.length > 0) {
                 return '?' + paramArgs.join('&');
@@ -692,7 +687,7 @@ angular.module('bby-query-mixer.recommendations').controller('RecommendationsCtr
             var endpointSelection = $scope.endpoint.selected ? baseUrl += ($scope.endpoint.selected) : '';
             var categoryOption = $scope.category.value ? baseUrl += ('(categoryId='+$scope.category.value+')') : '';
             var addKey = $scope.apiKey ? baseUrl += ('?apiKey='+$scope.apiKey):'';
-            baseUrl += '&callback=JSON_CALLBACK';
+
             return baseUrl;
         };
 
@@ -713,7 +708,7 @@ angular.module('bby-query-mixer.recommendations').controller('RecommendationsCtr
                 var eventActionName = "recommendation query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             }else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";
@@ -768,7 +763,6 @@ angular.module('bby-query-mixer.smartLists').controller('SmartListsCtrl', [
             var baseUrl = 'https://api.bestbuy.com/beta/products/';
             var endpointSelection = $scope.endpoint.selected ? baseUrl += ($scope.endpoint.selected) : '';
             var addKey = $scope.apiKey ? baseUrl += ('?apiKey='+$scope.apiKey):'';
-            baseUrl += '&callback=JSON_CALLBACK';
             return baseUrl;
         };
 
@@ -789,7 +783,7 @@ angular.module('bby-query-mixer.smartLists').controller('SmartListsCtrl', [
                 var eventActionName = "smart lists query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             }else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";
@@ -1026,7 +1020,7 @@ angular.module('bby-query-mixer.stores').controller('storesCtrl', [
             var checkPageSize = (($scope.pageSize)&&($scope.pageSize !== 10)) ? queryParams.push('&pageSize='+$scope.pageSize) : '';
             var checkWhichPage = (($scope.whichPage)&&($scope.whichPage !== 1)) ? queryParams.push('&page='+$scope.whichPage) : '';
                         
-            queryParams.push('&callback=JSON_CALLBACK&format=json');
+            queryParams.push('&format=json');
             var parensCheck = searchArgs.length === 0 ? baseUrl += (searchArgs.join('')) : baseUrl += ('('+searchArgs.join('&')+')');
             baseUrl += queryParams.join('');
             return baseUrl
@@ -1049,7 +1043,7 @@ angular.module('bby-query-mixer.stores').controller('storesCtrl', [
                 var eventActionName = "stores query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             } else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";
@@ -1201,7 +1195,7 @@ angular.module('bby-query-mixer.categories').controller('CategoriesCtrl', [
                     (queryParams += '&show=id,name'):'';
             
 
-            queryParams += '&callback=JSON_CALLBACK&format=json';
+            queryParams += '&format=json';
 
             return queryUrl + queryParams;
         };
@@ -1223,7 +1217,7 @@ angular.module('bby-query-mixer.categories').controller('CategoriesCtrl', [
                 var eventActionName = "categories query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             } else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";

--- a/app/recommendations/recommendations.html
+++ b/app/recommendations/recommendations.html
@@ -52,7 +52,6 @@
                     <p ng-show="endpoint.selected"><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation/recommendations-api" target="_blank">endpoint</a> : <span ng-bind="endpoint.selected"></span></p>
                     <p ng-show="category.value"><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation/products-api#documentation/products-api-categorizations" target="_blank">categoryId</a> : (categoryPath.id=<span ng-bind="category.value"></span>)</p>
                     <p><a class="breakdownLabel" href="https://remix.mashery.com/member/register" target="_blank">apiKey</a> : ?apiKey=<span ng-bind="apiKey"></span><span ng-show="sortBy != 'none'"></p>
-                    <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">callback</a> : &callback=JSON_CALLBACK</span></p>
                 </div>
             </div>
         <h4 class="container">Complete URL</h4>

--- a/app/recommendations/recommendations.js
+++ b/app/recommendations/recommendations.js
@@ -15,7 +15,7 @@ angular.module('bby-query-mixer.recommendations').controller('RecommendationsCtr
             var endpointSelection = $scope.endpoint.selected ? baseUrl += ($scope.endpoint.selected) : '';
             var categoryOption = $scope.category.value ? baseUrl += ('(categoryId='+$scope.category.value+')') : '';
             var addKey = $scope.apiKey ? baseUrl += ('?apiKey='+$scope.apiKey):'';
-            baseUrl += '&callback=JSON_CALLBACK';
+
             return baseUrl;
         };
 
@@ -36,7 +36,7 @@ angular.module('bby-query-mixer.recommendations').controller('RecommendationsCtr
                 var eventActionName = "recommendation query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             }else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";

--- a/app/smartLists/smartLists.html
+++ b/app/smartLists/smartLists.html
@@ -45,7 +45,6 @@
                     <p ng-show="endpoint.selected"><a class="breakdownLabel" href="" target="_blank">endpoint</a> : <span ng-bind="endpoint.selected"></span></p>
                     <p ng-show="category.value"><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation/products-api#documentation/products-api-categorizations" target="_blank">categoryId</a> : (categoryPath.id=<span ng-bind="category.value"></span>)</p>
                     <p><a class="breakdownLabel" href="https://remix.mashery.com/member/register" target="_blank">apiKey</a> : ?apiKey=<span ng-bind="apiKey"></span><span ng-show="sortBy != 'none'"></p>
-                    <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">callback</a> : &callback=JSON_CALLBACK</span></p>
                 </div>
             </div>
         <h4 class="container">Complete URL</h4>

--- a/app/smartLists/smartLists.js
+++ b/app/smartLists/smartLists.js
@@ -11,7 +11,6 @@ angular.module('bby-query-mixer.smartLists').controller('SmartListsCtrl', [
             var baseUrl = 'https://api.bestbuy.com/beta/products/';
             var endpointSelection = $scope.endpoint.selected ? baseUrl += ($scope.endpoint.selected) : '';
             var addKey = $scope.apiKey ? baseUrl += ('?apiKey='+$scope.apiKey):'';
-            baseUrl += '&callback=JSON_CALLBACK';
             return baseUrl;
         };
 
@@ -32,7 +31,7 @@ angular.module('bby-query-mixer.smartLists').controller('SmartListsCtrl', [
                 var eventActionName = "smart lists query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             }else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";

--- a/app/stores/stores.html
+++ b/app/stores/stores.html
@@ -181,8 +181,6 @@
 
                 <p ng-show="(pageSize !== 10) || (whichPage !== 1)"><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#pagination-pagination" target="_blank">pagination</a> : <span ng-show="(pageSize !== 10)">pageSize=<span ng-bind="pageSize"></span></span><span ng-show="(whichPage !== 1)">&page=<span ng-bind="whichPage"></span></span></p>
 
-                <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">callback</a> : &callback=JSON_CALLBACK</p>
-
                 <p><a class="breakdownLabel" href="https://developer.bestbuy.com/documentation#responseFormat-response-format" target="_blank">responseFormat</a> : &format=json</p>
 
 

--- a/app/stores/stores.js
+++ b/app/stores/stores.js
@@ -62,7 +62,7 @@ angular.module('bby-query-mixer.stores').controller('storesCtrl', [
             var checkPageSize = (($scope.pageSize)&&($scope.pageSize !== 10)) ? queryParams.push('&pageSize='+$scope.pageSize) : '';
             var checkWhichPage = (($scope.whichPage)&&($scope.whichPage !== 1)) ? queryParams.push('&page='+$scope.whichPage) : '';
                         
-            queryParams.push('&callback=JSON_CALLBACK&format=json');
+            queryParams.push('&format=json');
             var parensCheck = searchArgs.length === 0 ? baseUrl += (searchArgs.join('')) : baseUrl += ('('+searchArgs.join('&')+')');
             baseUrl += queryParams.join('');
             return baseUrl
@@ -85,7 +85,7 @@ angular.module('bby-query-mixer.stores').controller('storesCtrl', [
                 var eventActionName = "stores query success";
                 GaService.clickQueryButtonEvent(eventActionName, $scope.apiKey);
 
-                HttpClientService.httpClient(query).jsonp_query(successFn, errorFn);
+                HttpClientService.httpClient(query).get(successFn, errorFn);
             } else if ($scope.apiKey ===  ""){
                 $scope.errorResult = true;
                 $scope.results = "Please enter your API Key";

--- a/app/test/categories_test.js
+++ b/app/test/categories_test.js
@@ -39,24 +39,24 @@ describe('bby-query-mixer.categories module', function () {
 	        expect(scope.buildRemixQuery).toBeDefined();
 	    });
 	    it('should build a query string', function (){
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories?apiKey=youreAnApiKey&format=json');
 	    });
 	    it('should update pagination in the query string', function (){
 	        scope.pageSize = '12';
 	        scope.whichPage = '3';
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories?apiKey=youreAnApiKey&pageSize=12&page=3&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories?apiKey=youreAnApiKey&pageSize=12&page=&format=json');
 	    });
 	   	it('should add category name if needed', function (){
 	        scope.categoryName = 'awesomeProducts';
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories(name=awesomeProducts*)?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories(name=awesomeProducts*)?apiKey=youreAnApiKey&format=json');
 	    });
 	   	it('should add category id if needed', function (){
 	        scope.categoryId = 'abcat0401000';
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories(id=abcat0401000)?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories(id=abcat0401000)?apiKey=youreAnApiKey&format=json');
 	    });
 	   	it('should add the correct response attributes', function (){
 	        scope.categoryResponse.list = ['id','name','subcategory'];
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories?apiKey=youreAnApiKey&show=id,name,subcategory&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories?apiKey=youreAnApiKey&show=id,name,subcategory&format=json');
 	    });	 	    
     });
 

--- a/app/test/categories_test.js
+++ b/app/test/categories_test.js
@@ -44,7 +44,7 @@ describe('bby-query-mixer.categories module', function () {
 	    it('should update pagination in the query string', function (){
 	        scope.pageSize = '12';
 	        scope.whichPage = '3';
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories?apiKey=youreAnApiKey&pageSize=12&page=&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/categories?apiKey=youreAnApiKey&pageSize=12&page=3&format=json');
 	    });
 	   	it('should add category name if needed', function (){
 	        scope.categoryName = 'awesomeProducts';

--- a/app/test/openBox_test.js
+++ b/app/test/openBox_test.js
@@ -31,31 +31,31 @@ describe('bby-query-mixer.productSearch module', function () {
                 expect(scope.buildRemixQuery).toBeDefined();
             });
             it('should build a query string', function (){
-                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox&callback=JSON_CALLBACK');
+                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox');
             });
             it('should update pagination in the query string', function (){
                 scope.pageSize = '12';
                 scope.whichPage = '3';
-                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox&callback=JSON_CALLBACK&pageSize=12&page=3');
+                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox&pageSize=12&page=3');
             });
             it('should search by category id', function (){
                 scope.searchSelection.value = "category";
                 scope.category.value = 'pcmcat209400050001'
-                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox(categoryId=pcmcat209400050001)&callback=JSON_CALLBACK');
+                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox(categoryId=pcmcat209400050001)');
             });
             it('should search for all skus', function (){
                 scope.searchSelection.value = "allSkus";
-                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox&callback=JSON_CALLBACK');
+                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox');
             });
             it('should add list of skus', function (){
                 scope.searchSelection.value = "skuList";
                 scope.skuList = '123,321';
-                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox(sku%20in(123,321))&callback=JSON_CALLBACK');
+                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/openBox(sku%20in(123,321))');
             });
             it('should add singlesku', function (){
                 scope.searchSelection.value = "singleSku";
                 scope.singleSku = '123';
-                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/123/openBox&callback=JSON_CALLBACK');
+                expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/beta/products/123/openBox');
             });
     });
 

--- a/app/test/productSearch_test.js
+++ b/app/test/productSearch_test.js
@@ -34,28 +34,28 @@ describe('bby-query-mixer.productSearch module', function () {
 
             it('should return a url when apikey passed in', function () {
                 scope.apiKey = "youreAnApiKey";
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products?apiKey=youreAnApiKey&format=json");
             });
 
             it('should return a query string with no apiKey parameter when no key provided', function () {
                 scope.apiKey='';
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products?callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products");
             });
 
             it('should update the category id value when category is changed', function () {
                 scope.category = {
                     value: "abcat33"
                 };
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products((categoryPath.id=abcat33))?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products((categoryPath.id=abcat33))?apiKey=youreAnApiKey&format=json");
                 scope.category.value = "abcat34";
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products((categoryPath.id=abcat34))?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products((categoryPath.id=abcat34))?apiKey=youreAnApiKey&format=json");
             });
 
             it('should return a query string with a sort filter and sortOrder when specified', function () {
                 scope.category.value = "someCategory";
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products((categoryPath.id=someCategory))?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products((categoryPath.id=someCategory))?apiKey=youreAnApiKey&format=json");
                 scope.sortOrder.value = "desc";
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products((categoryPath.id=someCategory))?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products((categoryPath.id=someCategory))?apiKey=youreAnApiKey&format=json");
             });
             it('should return the right parens when sku in query is made', function () {
                 scope.dynamicForms= [{value:{productAttribute:'sku'},opt:{value:' in '},complexVal:'123, 456'}]
@@ -64,28 +64,28 @@ describe('bby-query-mixer.productSearch module', function () {
                 scope.attributeOption.value = 'sku';
                 scope.operator.value = ' in ';
                 scope.complexVal = '123, 456';
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(sku in (123, 456))?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(sku in (123, 456))?apiKey=youreAnApiKey&format=json");
             });
             it('should add an asterisk after category path name', function () {
                 scope.dynamicForms= [{value:{productAttribute:'categoryPath.name'},opt:{value:'='},complexVal:'Home Theater'}]
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(categoryPath.name=Home Theater*)?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(categoryPath.name=Home Theater*)?apiKey=youreAnApiKey&format=json");
             });            
             it('should return add faceting when specified', function () {
                 scope.facetAttribute.productAttribute = 'color';
                 scope.facetNumber = 11;
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products?apiKey=youreAnApiKey&facet=color,11&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products?apiKey=youreAnApiKey&facet=color,11&format=json");
             });
             it('should add bad values to query so that remix returns the proper error status', function () {
                 scope.dynamicForms= [{value:{productAttribute:'bestSellingRank'},opt:{value:'='},complexVal:'wwwwwwwwww'}]
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(bestSellingRank=wwwwwwwwww)?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(bestSellingRank=wwwwwwwwww)?apiKey=youreAnApiKey&format=json");
             });
             it('should add the star value to the query when selected', function () {
                 scope.dynamicForms= [{value:{productAttribute:'onSale'},opt:{value:'='},complexVal:'*'}];
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(onSale=*)?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(onSale=*)?apiKey=youreAnApiKey&format=json");
             });
             it('should allow invalid page sizes so remix can return the real error message', function () {
                 scope.pageSize = 111;
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products?apiKey=youreAnApiKey&pageSize=111&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products?apiKey=youreAnApiKey&pageSize=111&format=json");
             });              
         });
         describe('buildParams function', function () {
@@ -93,36 +93,36 @@ describe('bby-query-mixer.productSearch module', function () {
                 scope.apiKey = '';
                 scope.sortBy = {value : 'sku'};
                 scope.sortOrder.value = 'asc';
-                expect(scope.buildParams()).toEqual('?sort=sku.asc&callback=JSON_CALLBACK&format=json');
+                expect(scope.buildParams()).toEqual('?sort=sku.asc&format=json');
             });
             it('should return sortBy and sortOrder asc when only sortBy selected', function () {
                 scope.apiKey = '';
                 scope.sortBy = {value : 'sku'};
                 scope.sortOrder.value = 'desc';
 
-                expect(scope.buildParams()).toEqual('?sort=sku.desc&callback=JSON_CALLBACK&format=json');
+                expect(scope.buildParams()).toEqual('?sort=sku.desc&format=json');
             });
             it('should return apiKey when only apiKey specified', function () {
                 scope.apiKey = 'someApiKey';
-                expect(scope.buildParams()).toEqual('?apiKey=someApiKey&callback=JSON_CALLBACK&format=json');
+                expect(scope.buildParams()).toEqual('?apiKey=someApiKey&format=json');
             });
             it('should return both apiKey and sortBy with sortOrder when both specified', function () {
                 scope.apiKey = 'someApiKey';
                 scope.sortBy = {value : 'sku'};
                 scope.sortOrder.value = 'desc';
 
-                expect(scope.buildParams()).toEqual('?apiKey=someApiKey&sort=sku.desc&callback=JSON_CALLBACK&format=json');
+                expect(scope.buildParams()).toEqual('?apiKey=someApiKey&sort=sku.desc&format=json');
             });
             it('should add faceting when it\'s defined', function () {
                 scope.facetAttribute.productAttribute = 'manufacturer';
                 scope.facetNumber = '3';
-                expect(scope.buildParams()).toEqual('?apiKey=youreAnApiKey&facet=manufacturer,3&callback=JSON_CALLBACK&format=json');
+                expect(scope.buildParams()).toEqual('?apiKey=youreAnApiKey&facet=manufacturer,3&format=json');
             });
             it('construct pagination only when needed', function () {
-                expect(scope.buildParams()).toEqual('?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json');
+                expect(scope.buildParams()).toEqual('?apiKey=youreAnApiKey&format=json');
                 scope.pageSize = 11;
                 scope.whichPage = 3;
-                expect(scope.buildParams()).toEqual('?apiKey=youreAnApiKey&pageSize=11&page=3&callback=JSON_CALLBACK&format=json');
+                expect(scope.buildParams()).toEqual('?apiKey=youreAnApiKey&pageSize=11&page=3&format=json');
             });
         });
         describe('reset query function', function () {
@@ -165,7 +165,7 @@ describe('bby-query-mixer.productSearch module', function () {
         describe('dynamic forms functionality', function () {
             it('should compile the array of forms and add it to the remix query url', function () {
                 scope.dynamicForms= [{value:{productAttribute:'foo'},opt:{value:'='},complexVal:'foo'}]
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(foo=foo)?apiKey=youreAnApiKey&callback=JSON_CALLBACK&format=json");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products(foo=foo)?apiKey=youreAnApiKey&format=json");
             });
              it('should add/delete forms from the dynamic attributes list', function () {
                 scope.dynamicForms = [{value:{productAttribute:'foo'},opt:{value:'='},complexVal:'foo'}]

--- a/app/test/productSearch_test.js
+++ b/app/test/productSearch_test.js
@@ -39,7 +39,7 @@ describe('bby-query-mixer.productSearch module', function () {
 
             it('should return a query string with no apiKey parameter when no key provided', function () {
                 scope.apiKey='';
-                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products");
+                expect(scope.buildRemixQuery()).toEqual("https://api.bestbuy.com/v1/products?format=json");
             });
 
             it('should update the category id value when category is changed', function () {

--- a/app/test/recommendations_test.js
+++ b/app/test/recommendations_test.js
@@ -65,7 +65,7 @@ describe('bby-query-mixer.recommendations module', function () {
             });
 
             it('should return an error in an array on a failing response', function () {
-                $httpBackend.expectJSONP('https://api.bestbuy.com/beta/products/trendingViewed?apiKey=inactiveKey').respond(403, {
+                $httpBackend.expectGET('https://api.bestbuy.com/beta/products/trendingViewed?apiKey=inactiveKey').respond(403, {
                     status: 403,
                     errorMessage: "Account Inactive",
                     help: "http://developer.bestbuy.com/get-started"

--- a/app/test/recommendations_test.js
+++ b/app/test/recommendations_test.js
@@ -49,7 +49,7 @@ describe('bby-query-mixer.recommendations module', function () {
 
             it('should return a url when apiKey is supplied', function () {
                 scope.apiKey = 'someApiKey';
-                expect(scope.buildRecommendationsQuery()).toEqual('https://api.bestbuy.com/beta/products/?apiKey=someApiKey&callback=JSON_CALLBACK')
+                expect(scope.buildRecommendationsQuery()).toEqual('https://api.bestbuy.com/beta/products/?apiKey=someApiKey')
             });
         });
 
@@ -65,7 +65,7 @@ describe('bby-query-mixer.recommendations module', function () {
             });
 
             it('should return an error in an array on a failing response', function () {
-                $httpBackend.expectJSONP('https://api.bestbuy.com/beta/products/trendingViewed?apiKey=inactiveKey&callback=JSON_CALLBACK').respond(403, {
+                $httpBackend.expectJSONP('https://api.bestbuy.com/beta/products/trendingViewed?apiKey=inactiveKey').respond(403, {
                     status: 403,
                     errorMessage: "Account Inactive",
                     help: "http://developer.bestbuy.com/get-started"

--- a/app/test/smartLists_test.js
+++ b/app/test/smartLists_test.js
@@ -23,9 +23,9 @@ describe('bby-query-mixer.smartLists module', function () {
             });
             it('should add the appropriate endpoint', function (){
                 scope.endpoint.selected = 'activeAdventurer';
-                expect(scope.buildSmartListsQuery()).toEqual('https://api.bestbuy.com/beta/products/activeAdventurer&callback=JSON_CALLBACK');
+                expect(scope.buildSmartListsQuery()).toEqual('https://api.bestbuy.com/beta/products/activeAdventurer');
                 scope.endpoint.selected = 'connectedHome';
-                expect(scope.buildSmartListsQuery()).toEqual('https://api.bestbuy.com/beta/products/connectedHome&callback=JSON_CALLBACK');            
+                expect(scope.buildSmartListsQuery()).toEqual('https://api.bestbuy.com/beta/products/connectedHome');            
             });
         });
         describe('invoke recommendations query function', function (){

--- a/app/test/stores_test.js
+++ b/app/test/stores_test.js
@@ -37,78 +37,78 @@ describe('bby-query-mixer.stores module', function () {
 	    	expect(scope.buildRemixQuery).toBeDefined();
 	    });
 	    it('should build a query string', function (){
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores?apiKey=testKey&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores?apiKey=testKey&format=json');
 	    });
 	    it('should update pagination in the query string', function (){
 	        var queryParams = [];
 	        scope.pageSize = '12';
 	        scope.whichPage = '3';
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores?apiKey=testKey&pageSize=12&page=3&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores?apiKey=testKey&pageSize=12&page=3&format=json');
 	    });
 	    it('should add an ampersand in front of services list, but only if needed', function (){
 	     	scope.apiKey = 'testKey';   	        
 	        scope.searchSelection.value = 'city';
 	        scope.servicesOption.list = ['foo'];
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((city=)&((services.service=foo)))?apiKey=testKey&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((city=)&((services.service=foo)))?apiKey=testKey&format=json');
 	        scope.searchSelection.value = false;
-            expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((services.service=foo))?apiKey=testKey&callback=JSON_CALLBACK&format=json');
+            expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((services.service=foo))?apiKey=testKey&format=json');
 	    });
 	   	it('should add list of SKUs to the url', function (){
 	        scope.skuList = '6461052,5909042';
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores+products(sku%20in%20(6461052,5909042))?apiKey=testKey&show=products.sku,products.name,products.shortDescription,products.salePrice,products.regularPrice,products.addToCartURL,products.url,products.image,products.customerReviewCount,products.customerReviewAverage&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores+products(sku%20in%20(6461052,5909042))?apiKey=testKey&show=products.sku,products.name,products.shortDescription,products.salePrice,products.regularPrice,products.addToCartURL,products.url,products.image,products.customerReviewCount,products.customerReviewAverage&format=json');
 	    });
 	   	it('should add list of product options to the url', function (){
 	        scope.skuList = '6461052,5909042';
 	        scope.productOption.list = 'products.shortDescription'
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores+products(sku%20in%20(6461052,5909042))?apiKey=testKey&show=products.shortDescription&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores+products(sku%20in%20(6461052,5909042))?apiKey=testKey&show=products.shortDescription&format=json');
 	    });
 	   	it('should add list of store response options to the url', function (){
 	        scope.storeResponse.list = ['hours','name'];
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores?apiKey=testKey&show=hours,name&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores?apiKey=testKey&show=hours,name&format=json');
 	    });	 	   
 	   	it('should add list of product options AND store response options to the url', function (){
 	        scope.skuList = '6461052,5909042';
 	        scope.storeResponse.list = ['name','hours'];
 	        scope.productOption.list = 'products.shortDescription'
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores+products(sku%20in%20(6461052,5909042))?apiKey=testKey&show=products.shortDescription,name,hours&callback=JSON_CALLBACK&format=json');
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores+products(sku%20in%20(6461052,5909042))?apiKey=testKey&show=products.shortDescription,name,hours&format=json');
 	    });
 	    it('should search by city', function () {
 	    	scope.searchSelection.value = 'city';
 	    	scope.cityChoice = "EmeraldCity";
-	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((city=EmeraldCity))?apiKey=testKey&callback=JSON_CALLBACK&format=json')
+	        expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((city=EmeraldCity))?apiKey=testKey&format=json')
 	    });
 	    it('should search by postal code', function () {
 	    	scope.zipCode = '12345';
-            expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((postalCode=12345))?apiKey=testKey&callback=JSON_CALLBACK&format=json')
+            expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((postalCode=12345))?apiKey=testKey&format=json')
 
 	    });
 	    it('should search by lat long', function () {
 	    	scope.longitude = 50;
 	    	scope.latitude = 50;
-	    	expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((area(50,50,)))?apiKey=testKey&callback=JSON_CALLBACK&format=json')
+	    	expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((area(50,50,)))?apiKey=testKey&format=json')
 
 	    });	
 	    it('should search by storeid', function () {
 			scope.searchSelection.value = 'storeId';
 			scope.storeId = '54321';
-			expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((storeId=54321))?apiKey=testKey&callback=JSON_CALLBACK&format=json')
+			expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((storeId=54321))?apiKey=testKey&format=json')
 	    });	        	    		     
 	    it('should search by region/state', function () {
 			scope.searchSelection.value ='region';
 			scope.regionOption = {value:"Minnesota"};
-			expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((region=Minnesota))?apiKey=testKey&callback=JSON_CALLBACK&format=json');
+			expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((region=Minnesota))?apiKey=testKey&format=json');
 	    });   
 	    it('should add a key', function () {
 	    	scope.apiKey = "mySuperSecretApiKey";
-	    	expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores?apiKey=mySuperSecretApiKey&callback=JSON_CALLBACK&format=json');
+	    	expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores?apiKey=mySuperSecretApiKey&format=json');
 	    }); 	
 	   	it('should add store types', function () {
 	    	scope.storeType.list = ['Big Box', 'Express'];
-	    	expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores(((storeType=Big Box)|(storeType=Express)))?apiKey=testKey&callback=JSON_CALLBACK&format=json');
+	    	expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores(((storeType=Big Box)|(storeType=Express)))?apiKey=testKey&format=json');
 	    });  
 	   	it('should add store services', function () {
 	    	scope.servicesOption.list = ['Geek Squad', 'Best Buy for Enterprise'];
-	    	expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((services.service=Geek Squad)&(services.service=Best Buy for Enterprise))?apiKey=testKey&callback=JSON_CALLBACK&format=json');
+	    	expect(scope.buildRemixQuery()).toEqual('https://api.bestbuy.com/v1/stores((services.service=Geek Squad)&(services.service=Best Buy for Enterprise))?apiKey=testKey&format=json');
 	    });     
     });
 


### PR DESCRIPTION
@ecaron @Flet This should remove JSONP from the query builder.

It should be noted that /products /categories and /stores all work fine.  They respond with CORS headers.  

/openBox, /recommendations and /smartlists do not respond with the proper CORS headers and thus do not currently work.  We'll want to get those CORS headers added before we go live with this.